### PR TITLE
add comments

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -7,6 +7,7 @@ export const RESULT = 'RESULT'
 
 // get API
 
+// Все функции в этом файле обычно бы написали стрелочными
 export function beforeRequestApi(load) {
   return {
     type: GET_VALUE_API,
@@ -25,6 +26,7 @@ export default function getRequestApi() {
   return function (dispatch) {
     return fetch('https://www.cbr-xml-daily.ru/daily_json.js')
       .then(function (response) {
+        // Тут вроде можно использовать свойство response.ok
         if (response.status >= 200 && response.status < 300) {
           return response
         } else {
@@ -49,6 +51,8 @@ export default function getRequestApi() {
         dispatch(beforeRequestApi(API))
       })
       .catch(function (text) {
+        // По идее не надло в сторе хранить ошибку в таком красивом виде чтобы выводить
+        // Надо просто сохранить ошибку в стор а о том как ее вывести должны компоненты заботится
         return dispatch(errorRequestApi('Ошибка в получении данных: ' + text.message))
       })
   }
@@ -86,9 +90,12 @@ export function result(result) {
 
 //count 
 
+// Обычно так не пишут. Пишут const на каждой строчке 
 const SUM_OF_BASIC = 1000, // sum of basic valute
   MULTIPLICITY = 100
 
+// результат getState() можно сохранить в константу
+// Очень сложная функция и непонятно что делает надо упростить чтобы человеку сразу было понятно что тут к чему
 export function count() {
   return (dispatch, getState) => {
     if (getState().convertation.firstSelect.Name === 'Российских рублей') {

--- a/src/components/CreateInput.js
+++ b/src/components/CreateInput.js
@@ -6,6 +6,7 @@ function CreateInput(props) {
         value = props.defaultValue
     return (
         <div>
+            {/* Почему через defaultValue мне кажется тут через value нужно */}
             <input defaultValue={value} type='text' onChange={changeInput}></input>
         </div>
     )

--- a/src/components/CreateSelect.js
+++ b/src/components/CreateSelect.js
@@ -1,7 +1,10 @@
 import React from 'react'
+// Тут наыерно лучше абсолютный импорт использовать
+// src/containers/SearchValute
 import searchValute from './../containers/SearchValute'
 import PropTypes from 'prop-types'
 
+// Странное имя. Это скорее просто компонент Option
 function CreateOption(props) {
     return (
         <option>{props.Name}</option>
@@ -9,11 +12,14 @@ function CreateOption(props) {
 }
 
 function CreateSelect(props) {
+    // можно использовать деструкцию
     const list = props.list,         
     changeFirstOption = props.changeFirstOption,    
     changeSecondOption = props.changeSecondOption        
     return (<div>
         <h6>Из</h6>
+        {/* Селекты выглядят одинаково. Можно вынести в отдельный компонент.
+        Для стилей можно использовать styled-components */}
         <select style={{display: 'block'}} defaultValue = {searchValute('Доллар США', list).Name} onChange = {changeFirstOption}> 
              {list.map((option) => {                 
                     return <CreateOption key={option.ID} value={option.Name} CharCode={option.CharCode} Name={option.Name} />

--- a/src/components/CreateTable.js
+++ b/src/components/CreateTable.js
@@ -1,7 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+// Имя без Create
 function CreateTable(props) {
+    // Тут скорее бы деструкция использовалась
     const name = props.name,
         code = props.code,
         value = props.value,

--- a/src/containers/Api.js
+++ b/src/containers/Api.js
@@ -5,6 +5,8 @@ import Converter from './Converter'
 import CreateTable from '../components/CreateTable'
 import PropTypes from 'prop-types'
 
+// Не понял чем Containers отличаются от Components
+// Обычно в Containers нет верстки
 class Api extends React.Component {
     componentDidMount() {
         const { dispatch } = this.props
@@ -12,6 +14,7 @@ class Api extends React.Component {
     }
     render() {
         const { getload } = this.props
+        // Странный элемент стора. Лучше просто завести в значения в сторе. 1 для ошибки а другое для данных
         if (typeof getload !== 'object') {
             return <h3 className="container center-align">Загрузка данных...</h3>
         } else {
@@ -22,18 +25,24 @@ class Api extends React.Component {
             const arrayList = []
 
             for (const key in valute) {
+                // Можно было при загрузке данных преобьразовывать их в удобный формат и хранить в сторе в удобном формате
+                // Либо тут использоать Object.values() для получения списка значений
                 if (valute.hasOwnProperty(key)) {
                     arrayList.push(valute[key])
                 }
             }
 
             const list = arrayList.map((prop) => {
+                // В стрелочной функции если сразу идет возврат можно без return обойтись
+                // Судя повсему это строка таблицы создается а называется Table. Не очевидно
                 return <CreateTable key={prop.ID} name={prop.Name} code={prop.CharCode} value={prop.Value} target={prop.Nominal} />
             })
 
             return (<div className="container center-align">
                 <Converter  list={arrayList} />                                           
                 <h5 style={{ marginTop: '2em' }}>Курс на: {date}</h5>
+                {/* Тут обычно бы писали с использованием шаблонных строк */}
+                {/* https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/template_strings */}
                 <h5>Предыдущий срез на: {previousDate}</h5>
                 <h5>Отметка времени: {timestamp}</h5>
                 <table>
@@ -57,6 +66,7 @@ Api.propTypes = {
 }
 
 const mapStateToProps = state => {
+    // Тут можно без return написать
     return {
         getload: state.requestApi.getload
     }

--- a/src/containers/Converter.js
+++ b/src/containers/Converter.js
@@ -23,8 +23,11 @@ class Converter extends React.Component {
         })        
     }
 
+    // Можно переписать компонент на функиональный и использовать хуки для этого действия
+    // https://reactjs.org/docs/hooks-intro.html
     componentDidMount() {
         const { dispatch } = this.props        
+        // Выше была деструкция почему бы там еще и list не взять 
         dispatch(firstSelect(SearchValute('Доллар США', this.props.list)))        
         dispatch(secondSelect(SearchValute('Российских рублей', this.props.list)))
         dispatch(count())
@@ -44,6 +47,7 @@ class Converter extends React.Component {
     }
 
     changeFirstOption(e) {
+        // preventDefault не уверен что тут нужен
         e.preventDefault()
         const { dispatch } = this.props
         dispatch(firstSelect(SearchValute(e.target.value, this.props.list)))
@@ -62,6 +66,7 @@ class Converter extends React.Component {
             <CreateSelect list={this.props.list}
                 changeFirstOption={this.changeFirstOption}
                 changeSecondOption={this.changeSecondOption} />
+            {/* Очень сложно. Непонятно что происходит */}
             <h3>{typeof this.props.result !== 'number' || Number.isNaN(this.props.result) || this.props.getInput === '' ? 'введите число' : this.props.result.toFixed(2) + ' ' + this.props.secondSelect.CharCode}</h3>
         </div>
     }

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -5,6 +5,7 @@ import Api from './Api'
 
 const store = configureStore()
 
+// Тут можно функциональный компонент использовать
 export default class Root extends React.Component {
   render() {          
     return (

--- a/src/containers/SearchValute.js
+++ b/src/containers/SearchValute.js
@@ -1,3 +1,7 @@
+// Почему эта функция в сонтейнерах и еще с большой буквы файл
+// Выглядит как Контейнер
+// Можно переписать проще типа
+// listValute.find(element => element.Name === valute)
 export default function searchValute(valute, listValute) {              
     const firstDefaultSelect = listValute.filter((element) => {
         if (element.Name === valute) {

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -1,3 +1,5 @@
+// Можно было создавать шаблон с встроенной поддержеой redux
+// https://redux-toolkit.js.org/introduction/quick-start
 import { combineReducers } from 'redux'
 import {
   GET_VALUE_API, ERROR_GET_API,


### PR DESCRIPTION
Дмитрий, привет.
Не глянешь изменения, если есть желание?))
Я учел твои рекомендации, но остались вопросы.
actions:
не все функции написал стрелочными, т.к. не понял, как сделать абсолютный путь. Вставлял
jsconfig.js 
{
  "compilerOptions": {
    "baseUrl": "src"
  },
  "include": ["src"]
}
НЕ ПОМОГАЕТ.
С WebPack надо что-то сделать что ли? Или... Не подскажешь?

reducer:
Что-то есть страшное, что мне не хочется пользоваться шаблоном от Redux?)))
просто мне кажется удобным видеть чистые функции, даже если их там 50 штук будет

Wrapper: 
ты писал про странный элемент стора при условном рендере. Я не совсем понял, какие могут быть альтернативы: тут 2 состояния (запрос и полученный API). Компонент все равно перерисовывается при изменении, почему нельзя воспользоваться условием изменения типов данных?

Предыдущий срез на: {previousDate}
как бы ты содержимое <code> выше написал бы шаблонной строкой?

Converter:
Есть трудность с использованием hooks: писать компонент функциональный - значит actions помещать в mapDispatchToProps, но от туда нет доступа к state, чтобы при обновлении state работала функция count(). При установке mergeProps мой компонент встраивается, но НЕ РЕНДЕРИТСЯ!!! Может это из-за fetch? Ничего в гугл не нашел - везде пишут "вставляешь mergeProps, втыкаешь в connect и полетело..."
Селекты выглядят одинаково: они оба привязаны каждый к своему state, и если писать один на двоих, то придется в родителях извращаться, чтобы получив какую-нибудь метку при onChange, писать ЧТО-ТО, чтобы правильно раскладывать actions по своим селектам. Буду рад, если идейку подкинешь)))
Ну а с 65 по 73 строку там валидатор и условный вывод расчета, если в инпут совать будут всякую хрень.
В инпуте defaultValue: в просто value торчит начальный state, и хоть тресни - не удаляется при изменении поля. Опять же, я может что-то невкуриваю... 

Буду благодарен любым комментам, спасибо))